### PR TITLE
captureAudio={false}追記

### DIFF
--- a/src/QRScanner.js
+++ b/src/QRScanner.js
@@ -53,6 +53,7 @@ export default class QRScanner extends PureComponent {
          style={{
           flex: 1
         }}
+          captureAudio={false}
           onBarCodeRead={this._handleBarCodeRead}
           barCodeTypes={[RNCamera.Constants.BarCodeType.qr]}
           flashMode={!this.props.flashMode ? RNCamera.Constants.FlashMode.off : RNCamera.Constants.FlashMode.torch} 


### PR DESCRIPTION
## What
captureAudio={false}を追記

## Why
QRカメラ起動時にマイクの権限を要求したくないため（今回作成するアプリでは音声の取得は必要がないため）
